### PR TITLE
Use paragraph names specific to LocalGov Drupal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,31 +1,50 @@
-
-name: Test LocalGov Drupal
+name: Test LocalGov page components
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
-
+    name: 'Execute run-tests.sh'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone drupal_container
+      - name: setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: Clone drupal-container
         uses: actions/checkout@v2
         with:
           repository: localgovdrupal/drupal-container
           ref: master
 
-      - name: Create LocalGovDrupal project
+      - name: Create LocalGov Drupal project
         run: composer create-project --stability dev localgovdrupal/localgov-project html
 
-      - name: Checkout localgov_page_components branch to test
-        uses: actions/checkout@v2
-        with:
-          path: html/web/modules/contrib/localgov_page_components
+      - name: Save git branch and git repo names to env if not a pull request
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+
+      - name: Save git branch and git repo names to env if this is a pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+
+      - name: Setup package source and authentication for the test target
+        run: |
+          composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
+          composer global config github-oauth.github.com ${{ github.token }}
+
+      - name: Grab test target from this repo
+        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
 
       - name: Start Docker environment
         run: docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # LocalGovDrupal Page Components
 
-Reusable paragraphs library for LocalGovDrupal distribution.
+Reusable paragraphs library for the LocalGovDrupal distribution.
+
+## What's in it?
+### A node field
+Provides the **localgov_page_components** node field.  This field can be used to add new Page components or select an existing one within a node.  The recommended field widget is **Entity browser** which should use the *Page component* browser.
+
+This field is currently used in the localgov_services_page content type.  But it can be used in any other content type.
+
+### LinkIt integration
+The [LinkIt](https://www.drupal.org/project/linkit) module can use URLs belonging to localgov_link and localgov_contact Page components when the [localgov_paragraphs](https://packagist.org/packages/localgovdrupal/localgov_paragraphs) module is available.  Setup steps follow:
+- Access the LinkIt profile configuration page from */admin/config/content/linkit*.
+- Select the *Manage matchers* operation for the **Default** profile.  This should take you to */admin/config/content/linkit/manage/default/matchers*.
+- Click *Add matcher* which should land you at */admin/config/content/linkit/manage/default/matchers/add*.
+- Select **Page components** as the matcher.  *Save and continue*.  This should present the *Page components* matcher edit form.
+- Select *Link* and *Contact* as *Bundle restrictions*.  Other Paragraph types are unsupported at the moment.
+- *Limit search results* to 20.
+- Select the *Group by bundle* checkbox within *Bundle grouping*.
+- Select *Page components* from the **Substitution Type** dropdown within *URL substitution*.
+- *Save changes*.
+- Suggestions provided by LinkIt should now include localgov_link and localgov_contact Page components.
+
+## Known issues
+Some Page component edit forms (e.g. localgov_documents) try to open a modal.  This leads to a modal within a modal scenario which doesn't work.  The work around is to edit such Page components from their own edit page.  These can be looked up from  */admin/content/paragraphs*.

--- a/src/Plugin/Linkit/Substitution/ParagraphsLibraryItem.php
+++ b/src/Plugin/Linkit/Substitution/ParagraphsLibraryItem.php
@@ -27,14 +27,14 @@ use Drupal\linkit\SubstitutionInterface;
  * the Paragraph bundle and field names :(
  *
  * For now, URL is extracted from the following Paragraph bundle and fields:
- * - Contact:field_para_contact_url
- * - Advanced_links:field_url
+ * - Contact:localgov_contact_url
+ * - Link:localgov_url
  * Paragraph library items referring to other Paragraph bundles get their own
  * entity URL.
  *
  * @Substitution(
- *   id = "paragraphs_library_item_croydon",
- *   label = @Translation("Paragraphs library item (Croydon)"),
+ *   id = "paragraphs_library_item_localgovdrupal",
+ *   label = @Translation("Page components"),
  * )
  */
 class ParagraphsLibraryItem extends PluginBase implements SubstitutionInterface {
@@ -47,8 +47,8 @@ class ParagraphsLibraryItem extends PluginBase implements SubstitutionInterface 
    * @var array
    */
   const PARAGRAPH_TO_URL_FIELD_MAPPING = [
-    'contact' => 'field_para_contact_url',
-    'advanced_links' => 'field_url',
+    'localgov_contact' => 'localgov_contact_url',
+    'localgov_link' => 'localgov_url',
   ];
 
   /**

--- a/tests/src/Kernel/LinkItIntegrationTest.php
+++ b/tests/src/Kernel/LinkItIntegrationTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Drupal\Tests\localgov_page_components\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\paragraphs_library\Entity\LibraryItem;
+
+/**
+ * LinkIt integration tests for Link and Contact Page components.
+ *
+ * @group localgov_page_components
+ */
+class LinkItIntegrationTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['localgov_page_components'];
+
+  /**
+   * Integrates Page components with LinkIt.
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->container->get('module_installer')->install([
+      'user',
+      'node',
+      'linkit',
+    ]);
+    $this->container->get('module_installer')->install(['localgov_paragraphs']);
+
+    // Integrate Page components with LinkIt.
+    $this->defaultLinkItProfile = $this->container->get('entity_type.manager')->getStorage('linkit_profile')->load('default');
+    $this->assertNotEmpty($this->defaultLinkItProfile);
+
+    $this->pageComponentMatcherUuid = $this->defaultLinkItProfile->addMatcher([
+      'id' => 'entity:paragraphs_library_item',
+      'weight' => 0,
+      'settings' => [
+        'metadata' => '',
+        'bundles'  => [
+          'localgov_contact' => 'localgov_contact',
+          'localgov_link' => 'localgov_link',
+        ],
+        'group_by_bundle' => TRUE,
+        'substitution_type' => 'paragraphs_library_item_localgovdrupal',
+        'limit' => 20,
+      ],
+    ]);
+    $this->defaultLinkItProfile->save();
+  }
+
+  /**
+   * Test for searching Link and Contact Page components.
+   *
+   * Creates a localgov_link and a localgov_contact Page components and then
+   * searches those using our custom LinkIt matcher plugin.
+   */
+  public function testLinkItSearch() {
+
+    $this->addLinkAndContactPageComponents();
+
+    $matcher_plugin = $this->defaultLinkItProfile->getMatcher($this->pageComponentMatcherUuid);
+
+    // First, search for a Link.
+    $linkit_suggestions = $matcher_plugin->execute('Foo')->getSuggestions();
+    $linkit_suggestions_count = count($linkit_suggestions);
+
+    $expected_linkit_suggestions_count = 1;
+    $this->assertEqual($linkit_suggestions_count, $expected_linkit_suggestions_count);
+
+    // Next, search for a Contact.
+    $linkit_suggestions = $matcher_plugin->execute('Baz')->getSuggestions();
+    $linkit_suggestions_count = count($linkit_suggestions);
+
+    $expected_linkit_suggestions_count = 1;
+    $this->assertEqual($linkit_suggestions_count, $expected_linkit_suggestions_count);
+
+    // Lastly, search for both Link and Contact.
+    $linkit_suggestions = $matcher_plugin->execute('Test Paragraph')->getSuggestions();
+    $linkit_suggestions_count = count($linkit_suggestions);
+
+    $expected_linkit_suggestions_count = 2;
+    $this->assertEqual($linkit_suggestions_count, $expected_linkit_suggestions_count);
+  }
+
+  /**
+   * Creates necessary test data for search.
+   */
+  protected function addLinkAndContactPageComponents() {
+
+    $link_para = Paragraph::create([
+      'title' => 'Test Paragraph Foo bar',
+      'type'  => 'localgov_link',
+    ]);
+    $link_para->save();
+    $link_page_component = LibraryItem::create([
+      'label' => 'Link: Test Paragraph Foo bar',
+      'paragraphs' => $link_para,
+    ]);
+    $link_page_component->save();
+
+    $contact_para = Paragraph::create([
+      'title' => 'Test Paragraph Baz qux',
+      'type'  => 'localgov_contact',
+    ]);
+    $contact_para->save();
+    $contact_page_component = LibraryItem::create([
+      'label' => 'Contact: Test Paragraph Baz qux',
+      'paragraphs' => $contact_para,
+    ]);
+    $contact_page_component->save();
+  }
+
+  /**
+   * LinkIt profile.
+   *
+   * @var Drupal\linkit\ProfileInterface
+   */
+  protected $defaultLinkItProfile;
+
+  /**
+   * UUID value assigned to our custom Matcher.
+   *
+   * @var string
+   */
+  protected $pageComponentMatcherUuid = '';
+
+}


### PR DESCRIPTION
Update paragraph names to those from the LocalGov Drupal codebase.  Previously
it was using paragraphs names from the BHCC/Croydon codebase.

~**Todo**: Needs tests~