### PR TITLE
Page component embedding in WYSIWYG

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,8 @@ It is possible to embed Page components from within the WYSIWYG.  This is an *op
 - *Save configuration*.
 - If this text format is later selected when editing a textarea, the Page component embed button should appear in the WYSIWYG's toolbar.
 
+#### Troubleshooting
+If a Page component's markup does not conform to CKEditor's DTD rules, the embedded page component markup will break.  To avoid this, extend the DTD rules.  The [bundled CKEditor plugin](js/ckeditor-plugins/localgov_page_components/plugin.js) serves as an example.
+
 ## Known issues
 Some Page component edit forms (e.g. localgov_documents) try to open a modal.  This leads to a modal within a modal scenario which doesn't work.  The work around is to edit such Page components from their own edit page.  These can be looked up from  */admin/content/paragraphs*.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,3 @@ For best results, ensure CKEditor is [loading stylesheets](https://www.drupal.or
 
 #### Troubleshooting
 An embedded Page component's markup can break if it does not conform to CKEditor's DTD rules.  If this happens, extend the DTD rules.  The [bundled CKEditor plugin](js/ckeditor-plugins/localgov_page_components/plugin.js) serves as an example.
-
-## Known issues
-Some Page component edit forms (e.g. localgov_documents) try to open a modal.  This leads to a modal within a modal scenario which doesn't work.  The work around is to edit such Page components from their own edit page.  These can be looked up from  */admin/content/paragraphs*.

--- a/README.md
+++ b/README.md
@@ -9,17 +9,28 @@ Provides the **localgov_page_components** node field.  This field can be used to
 This field is currently used in the localgov_services_page content type.  But it can be used in any other content type.
 
 ### LinkIt integration
-The [LinkIt](https://www.drupal.org/project/linkit) module can use URLs belonging to localgov_link and localgov_contact Page components when the [localgov_paragraphs](https://packagist.org/packages/localgovdrupal/localgov_paragraphs) module is available.  Setup steps follow:
+When the [LinkIt](https://www.drupal.org/project/linkit) module is available, its **Default** profile will be configured to use URLs from localgov_link and localgov_contact Page components which come from the [localgov_paragraphs](https://packagist.org/packages/localgovdrupal/localgov_paragraphs) module.
+
+To configure **other** LinkIt profiles, follow these steps:
 - Access the LinkIt profile configuration page from */admin/config/content/linkit*.
-- Select the *Manage matchers* operation for the **Default** profile.  This should take you to */admin/config/content/linkit/manage/default/matchers*.
-- Click *Add matcher* which should land you at */admin/config/content/linkit/manage/default/matchers/add*.
+- Select the *Manage matchers* operation for the target profile.
+- Click *Add matcher*.
 - Select **Page components** as the matcher.  *Save and continue*.  This should present the *Page components* matcher edit form.
 - Select *Link* and *Contact* as *Bundle restrictions*.  Other Paragraph types are unsupported at the moment.
 - *Limit search results* to 20.
 - Select the *Group by bundle* checkbox within *Bundle grouping*.
 - Select *Page components* from the **Substitution Type** dropdown within *URL substitution*.
 - *Save changes*.
-- Suggestions provided by LinkIt should now include localgov_link and localgov_contact Page components.
+- Suggestions provided by LinkIt for this profile should now include localgov_link and localgov_contact Page components.
+
+### WYSIWYG integration
+It is possible to embed Page components from within the WYSIWYG.  This is an *optional* feature.  Setup steps are as follows:
+- Select the target text format from */admin/config/content/formats*.
+- Enable the **Display embedded entities** filter.
+- If the *Limit allowed HTML tags and correct faulty HTML* filter is enabled, add this tag in its filter settings: ```<drupal-entity data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button alt title>```
+- Drag the *Page component* button into the WYSIWYG's active toolbar.
+- *Save configuration*.
+- If this text format is later selected when editing a textarea, the Page component embed button should appear in the WYSIWYG's toolbar.
 
 ## Known issues
 Some Page component edit forms (e.g. localgov_documents) try to open a modal.  This leads to a modal within a modal scenario which doesn't work.  The work around is to edit such Page components from their own edit page.  These can be looked up from  */admin/content/paragraphs*.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ It is possible to embed Page components from within the WYSIWYG.  This is an *op
 - *Save configuration*.
 - If this text format is later selected when editing a textarea, the Page component embed button should appear in the WYSIWYG's toolbar.
 
+#### Good to know
+For best results, ensure CKEditor is [loading stylesheets](https://www.drupal.org/docs/theming-drupal/defining-a-theme-with-an-infoyml-file#ckeditor_stylesheets) for any embedded Page component.
+
 #### Troubleshooting
-If a Page component's markup does not conform to CKEditor's DTD rules, the embedded page component markup will break.  To avoid this, extend the DTD rules.  The [bundled CKEditor plugin](js/ckeditor-plugins/localgov_page_components/plugin.js) serves as an example.
+An embedded Page component's markup can break if it does not conform to CKEditor's DTD rules.  If this happens, extend the DTD rules.  The [bundled CKEditor plugin](js/ckeditor-plugins/localgov_page_components/plugin.js) serves as an example.
 
 ## Known issues
 Some Page component edit forms (e.g. localgov_documents) try to open a modal.  This leads to a modal within a modal scenario which doesn't work.  The work around is to edit such Page components from their own edit page.  These can be looked up from  */admin/content/paragraphs*.

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/entity_browser": "^2.5",
-	    "drupal/inline_entity_form": "^1.0-rc6",
+        "drupal/entity_embed": "^1.1",
+        "drupal/inline_entity_form": "^1.0-rc6",
         "drupal/linkit": "^6.0-beta1",
         "drupal/paragraphs": "^1.11"
     }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/entity_browser": "^2.5",
+        "drupal/entity_embed": "^1.1",
         "drupal/entity_usage": "^2.0",
         "drupal/inline_entity_form": "^1.0-rc6",
         "drupal/linkit": "^6.0-beta1",

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "drupal/entity_browser": "^2.5",
         "drupal/entity_embed": "^1.1",
+        "drupal/entity_usage": "^2.0",
         "drupal/inline_entity_form": "^1.0-rc6",
         "drupal/linkit": "^6.0-beta1",
         "drupal/paragraphs": "^1.11"

--- a/config/optional/core.entity_view_display.paragraphs_library_item.paragraphs_library_item.embedded.yml
+++ b/config/optional/core.entity_view_display.paragraphs_library_item.paragraphs_library_item.embedded.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraphs_library_item.embedded
+  module:
+    - entity_reference_revisions
+    - paragraphs_library
+id: paragraphs_library_item.paragraphs_library_item.embedded
+targetEntityType: paragraphs_library_item
+bundle: paragraphs_library_item
+mode: embedded
+content:
+  paragraphs:
+    label: hidden
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    region: content
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+hidden:
+  label: true
+  search_api_excerpt: true

--- a/config/optional/core.entity_view_mode.paragraphs_library_item.embedded.yml
+++ b/config/optional/core.entity_view_mode.paragraphs_library_item.embedded.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs_library
+id: paragraphs_library_item.embedded
+label: Embedded
+targetEntityType: paragraphs_library_item
+cache: true

--- a/config/optional/embed.button.page_component.yml
+++ b/config/optional/embed.button.page_component.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraphs_library_item.embedded
+    - entity_browser.browser.page_components_for_wysiwyg
+  module:
+    - entity_embed
+    - paragraphs_library
+label: 'Page component'
+id: page_component
+type_id: entity
+type_settings:
+  entity_type: paragraphs_library_item
+  bundles: {  }
+  display_plugins:
+    - 'view_mode:paragraphs_library_item.embedded'
+  entity_browser: page_components_for_wysiwyg
+  entity_browser_settings:
+    display_review: false
+icon:
+  data: iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAblJREFUOBGNU02OAWEQfc2H7kHEX4hEWLrDTCSuYLZO4BqOIBmxcgIHMLEza3sbEiL+w0qLv55+lWksekQl3f3l63qvql5VabVazVqtVrher3jFTNOEYRjweDyIxWLQJpOJdTweYVnWK3hsNhvE43FomgafzwfVarUwnU6F8c7gkGm3KwYgyDT30HVDMs5kMtC22611Pp/l5837yWG9XiORSEjGSimoRuMLvd6PqwaMms/nUCwW8f7+AWY7Ho8RCoWEIJVKQXU63+j3+/8SDIdDW7Q3lMufqFQqWCwWIh6T9Pv9UHxRWZbhZuwOU93tduh2u5jNZpIBfaPRKJTX63XD3e4oHH10XbfLySMQCCASiYhmwWAQnpvnCweS0R6/6pX+0+dwOGA0GknLw+GwiMhBUhyiZ2UQTH2YdqlUEg0IpLEcVSgUZLoul4tcPr4IzuVySKfTGAwGaLfbmM/nAqSfjDIHyQ3sEDklshv0Yxs5yjRpY71ex3K5dJ0DOpGAwNPpJJGpBZeJQiaTSWj2ZMky0fmZUYf9fi+Po4Fk0Gw2YW+kLJPTHjvuH9d9mbi+2WwW1WpVIjvBfgEtOdkcU4aJ3AAAAABJRU5ErkJggg==
+  uri: 'public://embed_buttons/paragraph.png'
+icon_uuid: null

--- a/config/optional/entity_browser.browser.page_components_for_wysiwyg.yml
+++ b/config/optional/entity_browser.browser.page_components_for_wysiwyg.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.paragraphs_library_browser
+  module:
+    - entity_browser_entity_form
+    - views
+name: page_components_for_wysiwyg
+label: 'Page components for WYSIWYG'
+display: iframe
+display_configuration:
+  width: '1185'
+  height: '746'
+  link_text: 'Select Page components'
+  auto_open: true
+selection_display: no_display
+selection_display_configuration: {  }
+widget_selector: tabs
+widget_selector_configuration: {  }
+widgets:
+  7da16125-6711-4239-8b57-b9816aacbea5:
+    settings:
+      view: paragraphs_library_browser
+      view_display: entity_browser
+      submit_text: 'Select Page component'
+      auto_select: false
+    uuid: 7da16125-6711-4239-8b57-b9816aacbea5
+    weight: 1
+    label: 'Available Page components'
+    id: view
+  1004df02-eee4-413f-ba2a-5116fd38e010:
+    settings:
+      entity_type: paragraphs_library_item
+      bundle: paragraphs_library_item
+      form_mode: default
+      submit_text: 'Save Page component'
+    uuid: 1004df02-eee4-413f-ba2a-5116fd38e010
+    weight: 2
+    label: 'Create Page component'
+    id: entity_form

--- a/js/ckeditor-plugins/localgov_page_components/plugin.js
+++ b/js/ckeditor-plugins/localgov_page_components/plugin.js
@@ -1,0 +1,26 @@
+/**
+ * @file
+ * A CKEditor plugin to apply site-specific changes.
+ *
+ * Our changes:
+ * - Convince the span tag to accept the meta tag as a child element.  This is
+ *   needed for geolocation fields.
+ *
+ * @see https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample.html
+ */
+
+(function fineTuneCKEditor(jQuery, Drupal, CKEDITOR) {
+  /**
+   * The span element should allow the meta element as a child.
+   */
+  function letSpanAcceptMetaAsChild() {
+    CKEDITOR.dtd.span.meta = 1;
+  }
+
+  CKEDITOR.plugins.add("localgov_page_components", {
+    /* eslint no-unused-vars: ["error", { "args": "none" }] */
+    beforeInit(editor) {
+      letSpanAcceptMetaAsChild();
+    }
+  });
+})(jQuery, Drupal, CKEDITOR);

--- a/js/ckeditor-plugins/localgov_page_components/plugin.js
+++ b/js/ckeditor-plugins/localgov_page_components/plugin.js
@@ -3,24 +3,29 @@
  * A CKEditor plugin to apply site-specific changes.
  *
  * Our changes:
- * - Convince the span tag to accept the meta tag as a child element.  This is
- *   needed for geolocation fields.
+ * - Convince the div and span tags to accept the meta tag as a child element.
+ *   This is needed for geolocation fields.
  *
  * @see https://ckeditor.com/docs/ckeditor4/latest/guide/plugin_sdk_sample.html
+ * @see CKEDITOR.htmlParser.fragment.fromHtml()
  */
 
 (function fineTuneCKEditor(jQuery, Drupal, CKEDITOR) {
   /**
-   * The span element should allow the meta element as a child.
+   * CKEditor DTD rule update.
+   *
+   * The div and span elements should allow the meta element as a child or
+   * *grandchild*.
    */
-  function letSpanAcceptMetaAsChild() {
+  function letDivAndSpanAcceptMetaAsChild() {
+    CKEDITOR.dtd.div.meta = 1;
     CKEDITOR.dtd.span.meta = 1;
   }
 
   CKEDITOR.plugins.add("localgov_page_components", {
     /* eslint no-unused-vars: ["error", { "args": "none" }] */
-    beforeInit(editor) {
-      letSpanAcceptMetaAsChild();
+    beforeInit: function(editor) {
+      letDivAndSpanAcceptMetaAsChild();
     }
   });
 })(jQuery, Drupal, CKEDITOR);

--- a/localgov_page_components.info.yml
+++ b/localgov_page_components.info.yml
@@ -6,5 +6,6 @@ package: 'LocalGov Drupal'
 dependencies:
   - entity_browser:entity_browser
   - entity_browser:entity_browser_entity_form
+  - entity_embed:entity_embed
   - inline_entity_form:inline_entity_form
   - paragraphs:paragraphs_library

--- a/localgov_page_components.info.yml
+++ b/localgov_page_components.info.yml
@@ -1,6 +1,6 @@
 name: 'Localgov Page Components'
 type: module
-description: 'Disguise "Paragraphs library" as "Page components" for better UX.'
+description: 'Disguises "Paragraphs library" as "Page components" for better UX.'
 core_version_requirement: ^8.9 || ^9
 package: 'LocalGov Drupal'
 dependencies:

--- a/localgov_page_components.install
+++ b/localgov_page_components.install
@@ -8,24 +8,6 @@
 use Drupal\localgov_core\FieldRenameHelper;
 
 /**
- * Update Field names in localgov page components.
- *
- * Field mapping between existing and new names:
- * field_page_components => localgov_page_components.
- *
- * This change creates and updates Drupal config entities.  Unless configuration
- * is *exported* after this update, later calls to 'drush deploy' or similar
- * will revert these changes.
- */
-function localgov_page_components_update_8001(&$sandbox) {
-
-  // Update field_ types fields provided by localgov_page_components.
-  FieldRenameHelper::renameField('field_page_components', 'localgov_page_components', 'node');
-
-  return t('Please export your sites configuration! Config entities for localgov_page_components where updated.');
-}
-
-/**
  * Implements hook_install().
  */
 function localgov_page_components_install($is_syncing) {
@@ -62,4 +44,46 @@ function localgov_page_components_install($is_syncing) {
     ],
   ]);
   $defaultLinkItProfile->save();
+}
+
+/**
+ * Update Field names in localgov page components.
+ *
+ * Field mapping between existing and new names:
+ * field_page_components => localgov_page_components.
+ *
+ * This change creates and updates Drupal config entities.  Unless configuration
+ * is *exported* after this update, later calls to 'drush deploy' or similar
+ * will revert these changes.
+ */
+function localgov_page_components_update_8001(&$sandbox) {
+
+  // Update field_ types fields provided by localgov_page_components.
+  FieldRenameHelper::renameField('field_page_components', 'localgov_page_components', 'node');
+
+  return t('Please export your sites configuration! Config entities for localgov_page_components where updated.');
+}
+
+/**
+ * Imports new optional config.
+ *
+ * Installs new dependency module and imports new optional config files.
+ */
+function localgov_page_components_update_8102(&$sandbox) {
+
+  try {
+    Drupal::service('module_installer')->install(['entity_embed']);
+
+    Drupal::service('config.installer')->installOptionalConfig();
+  }
+  catch (Exception $e) {
+    throw new UpdateException($e->getMessage());
+  }
+
+  $is_terminal = PHP_SAPI === 'cli' && getenv('TERM');
+  [$magenta, $colour_off] = $is_terminal ? ["\033[35m", "\033[0m"] : ['', ''];
+  return t('%magenta Please export site configuration.  New config entities added for the localgov_page_components module.%colour_off', [
+    '%magenta'    => $magenta,
+    '%colour_off' => $colour_off,
+  ]);
 }

--- a/localgov_page_components.install
+++ b/localgov_page_components.install
@@ -29,6 +29,10 @@ function localgov_page_components_update_8001(&$sandbox) {
  * Implements hook_install().
  */
 function localgov_page_components_install($is_syncing) {
+  $has_linkit = \Drupal::service('entity_type.manager')->hasDefinition('linkit_profile');
+  if (!$has_linkit) {
+    return;
+  }
 
   /** @var \Drupal\linkit\ProfileInterface $defaultLinkItProfile */
   $defaultLinkItProfile = \Drupal::service('entity_type.manager')->getStorage('linkit_profile')->load('default');

--- a/localgov_page_components.module
+++ b/localgov_page_components.module
@@ -150,3 +150,24 @@ function localgov_page_components_field_widget_multivalue_entity_browser_entity_
     $element['entity_browser']['#weight'] = 10;
   }
 }
+
+/**
+ * Implements hook_preprocess_entity_embed_container().
+ *
+ * Inserts the "data-quickedit-entity-id" attribute into the entity embed
+ * container div.  This attribute points to the embedded page component entity.
+ * This is needed as a workaround for a *core bug*.
+ *
+ * @see https://www.drupal.org/project/drupal/issues/3101267
+ */
+function localgov_page_components_preprocess_entity_embed_container(&$vars) {
+  $has_quickedit = Drupal::service('module_handler')->moduleExists('quickedit');
+  $embedded_entity = $vars['element']['#entity'];
+  $embedded_entity_type = $embedded_entity->getEntityType()->id();
+  $has_embedded_page_component = $embedded_entity_type === Constants::PARAGRAPHS_LIB_ENTITY_TYPE_ID;
+
+  if ($has_quickedit and $has_embedded_page_component) {
+    $page_component = $embedded_entity;
+    $vars['attributes']['data-quickedit-entity-id'] = Constants::PARAGRAPHS_LIB_ENTITY_TYPE_ID . '/' . $page_component->id();
+  }
+}

--- a/src/Plugin/CKEditorPlugin/PageComponentEmbed.php
+++ b/src/Plugin/CKEditorPlugin/PageComponentEmbed.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\localgov_page_components\Plugin\CKEditorPlugin;
+
+use Drupal\ckeditor\CKEditorPluginContextualInterface;
+use Drupal\editor\Entity\Editor;
+use Drupal\Component\Plugin\PluginBase;
+
+/**
+ * Fine tune CKEditor.
+ *
+ * Our changes:
+ * - Convince the span tag to accept the meta tag as a child element.  This is
+ *   needed for embedding entities with geolocation fields.
+ *
+ * @CKEditorPlugin (
+ *   id = "localgov_page_components",
+ *   label = @Translation("Page component embed")
+ * );
+ */
+class PageComponentEmbed extends PluginBase implements CKEditorPluginContextualInterface {
+
+  /**
+   * {@inheritdoc}
+   *
+   * This plugin should be loaded at all times.
+   */
+  public function isEnabled(Editor $editor) {
+
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Location of our CKEditor plugin file.
+   */
+  public function getFile() {
+
+    return drupal_get_path('module', 'localgov_page_components') . '/js/ckeditor-plugins/localgov_page_components/plugin.js';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isInternal() {
+
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDependencies(Editor $editor) {
+
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLibraries(Editor $editor) {
+
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfig(Editor $editor) {
+
+    return [];
+  }
+
+}


### PR DESCRIPTION
To embed Page components with Geolocation fields, we need to convince CKEditor
to accept meta tags within span tags.

New Entity embed button for the WYSIWYG.  This button triggers a modal dialog to
insert a new or existing Page component.