### PR TITLE
Bug fix: Documents edit within entity browser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,15 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/entity_browser": "^2.5",
-	    "drupal/inline_entity_form": "^1.0-rc6",
+        "drupal/inline_entity_form": "^1.0-rc6",
         "drupal/linkit": "^6.0-beta1",
         "drupal/paragraphs": "^1.11"
+    },
+    "extra": {
+        "patches": {
+            "drupal/entity_browser": {
+                "Entity browser assumes all forms on the route `entity_browser.edit_form` are entity browser forms #3130500": "https://www.drupal.org/files/issues/2020-04-24/3130500.patch"
+            }
+        }
     }
 }


### PR DESCRIPTION
Trying to add new documents into a Documents page component fails within an entity browser.  This is due to a known bug with the entity_browser module.  Applying a relevant patch.

@see https://www.drupal.org/project/entity_browser/issues/3130500

Resolves #23 