### PR TITLE
Fix: Substitution plugin API compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
-            drupal-version: '~10.0'
+            drupal-version: '~10.1'
             php-version: '8.2'
 
     steps:
@@ -110,8 +107,8 @@ jobs:
       matrix:
         include:
           - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+            drupal-version: '~10.1'
+            php-version: '8.2'
 
     steps:
 
@@ -142,12 +139,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+            drupal-version: '~10.1'
+            php-version: '8.2'
 
     steps:
 
@@ -177,12 +171,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+            drupal-version: '~10.1'
+            php-version: '8.2'
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.1'
             php-version: '8.2'
@@ -106,6 +109,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.1'
             php-version: '8.2'
@@ -139,6 +145,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.1'
             php-version: '8.2'
@@ -171,6 +180,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.1'
             php-version: '8.2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
             php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
-            php-version: '8.1'
+            php-version: '8.2'
 
     steps:
 
@@ -109,9 +109,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
           - localgov-version: '3.x'
             drupal-version: '~10.0'
             php-version: '8.1'

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/entity_browser": "^2.5",
         "drupal/inline_entity_form": "^1.0-rc6",
-        "drupal/linkit": "^6.0-beta1",
+        "drupal/linkit": "^6.1.1",
         "drupal/paragraphs": "^1.11"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/entity_browser": "^2.5",
         "drupal/inline_entity_form": "^1.0-rc6",
-        "drupal/linkit": "^6.0.2",
+        "drupal/linkit": "~6.0.2 || ^6.1.1",
         "drupal/paragraphs": "^1.11"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/entity_browser": "^2.5",
         "drupal/inline_entity_form": "^1.0-rc6",
-        "drupal/linkit": "^6.1.1",
+        "drupal/linkit": "^6.0.2",
         "drupal/paragraphs": "^1.11"
     },
     "extra": {

--- a/localgov_page_components.info.yml
+++ b/localgov_page_components.info.yml
@@ -1,10 +1,11 @@
 name: 'Localgov Page Components'
 type: module
 description: 'Disguise "Paragraphs library" as "Page components" for better UX.'
-core_version_requirement: ">=10.1"
+core_version_requirement: ">=9"
 package: 'LocalGov Drupal'
 dependencies:
   - entity_browser:entity_browser
   - entity_browser:entity_browser_entity_form
   - inline_entity_form:inline_entity_form
+  - linkit:linkit (>=6.0.2)
   - paragraphs:paragraphs_library

--- a/localgov_page_components.info.yml
+++ b/localgov_page_components.info.yml
@@ -1,7 +1,7 @@
 name: 'Localgov Page Components'
 type: module
 description: 'Disguise "Paragraphs library" as "Page components" for better UX.'
-core_version_requirement: ^9 || ^10
+core_version_requirement: ">=10.1"
 package: 'LocalGov Drupal'
 dependencies:
   - entity_browser:entity_browser

--- a/src/Plugin/Linkit/Substitution/ParagraphsLibraryItem.php
+++ b/src/Plugin/Linkit/Substitution/ParagraphsLibraryItem.php
@@ -7,7 +7,7 @@ namespace Drupal\localgov_page_components\Plugin\Linkit\Substitution;
 use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\GeneratedUrl;
+use Drupal\Core\Url;
 use Drupal\linkit\SubstitutionInterface;
 
 /**
@@ -60,8 +60,8 @@ class ParagraphsLibraryItem extends PluginBase implements SubstitutionInterface 
   public function getUrl(EntityInterface $paragraphs_library_item) {
 
     $uri        = NULL;
-    $empty_uri  = (new GeneratedUrl)->setGeneratedUrl('');
-    $entity_uri = $paragraphs_library_item->toUrl('canonical')->toString(TRUE);
+    $empty_uri  = Url::fromUri('base:');
+    $entity_uri = $paragraphs_library_item->toUrl('canonical');
 
     $paragraph_bundle = $paragraphs_library_item->paragraphs->entity->getType();
     $is_unknown_bundle = !array_key_exists($paragraph_bundle, self::PARAGRAPH_TO_URL_FIELD_MAPPING);
@@ -77,10 +77,10 @@ class ParagraphsLibraryItem extends PluginBase implements SubstitutionInterface 
       $uri = $empty_uri;
     }
     elseif ($fieldtype === 'link') {
-      $uri = $paragraphs_library_item->paragraphs->entity->{$fieldname}[0]->getUrl()->toString(TRUE);
+      $uri = $paragraphs_library_item->paragraphs->entity->{$fieldname}[0]->getUrl();
     }
     elseif ($fieldtype === 'string') {
-      $uri = (new GeneratedUrl)->setGeneratedUrl($paragraphs_library_item->paragraphs->entity->{$fieldname}->value);
+      $uri = Url::fromUri($paragraphs_library_item->paragraphs->entity->{$fieldname}->value);
     }
     else {
       $uri = $entity_uri;

--- a/tests/src/Kernel/LinkItIntegrationTest.php
+++ b/tests/src/Kernel/LinkItIntegrationTest.php
@@ -32,7 +32,14 @@ class LinkItIntegrationTest extends KernelTestBase {
    *
    * @var \Drupal\linkit\SuggestionManager
    */
-  private $suggestionManager;
+  protected $suggestionManager;
+
+  /**
+   * Our LinkIt substitution plugin instance.
+   *
+   * @var \Drupal\linkit\SubstitutionInterface
+   */
+  protected $substitutionPlugin;
 
   /**
    * Integrates Page components with LinkIt.
@@ -53,14 +60,14 @@ class LinkItIntegrationTest extends KernelTestBase {
     // Integrate Page components with LinkIt.
     $this->defaultLinkItProfile = $this->container->get('entity_type.manager')->getStorage('linkit_profile')->load('default');
     $this->suggestionManager = $this->container->get('linkit.suggestion_manager');
-
+    $this->substitutionPlugin = $this->container->get('plugin.manager.linkit.substitution')->createInstance('paragraphs_library_item_localgovdrupal');
   }
 
   /**
    * Test for searching Link and Contact Page components.
    *
-   * Creates a localgov_link and a localgov_contact Page components and then
-   * searches those using our custom LinkIt matcher plugin.
+   * Creates a localgov_link, a localgov_contact, and a localgov_image Page
+   * components and then searches those using our custom LinkIt matcher plugin.
    */
   public function testLinkItSearch() {
 
@@ -89,13 +96,43 @@ class LinkItIntegrationTest extends KernelTestBase {
   }
 
   /**
-   * Creates necessary test data for search.
+   * Test for substituting page components with their URLs.
+   *
+   * For localgov_link and localgov_contact page components, substitution will
+   * result in a URL where the URL is sourced from a field value.
+   *
+   * For localgov_image page component, substitution will produce the page
+   * component's own URL.
    */
-  protected function addLinkAndContactPageComponents() {
+  public function testLinkItSubstitution() {
+
+    $page_components = $this->addLinkAndContactPageComponents();
+
+    $link_url = $this->substitutionPlugin->getUrl($page_components['localgov_link'])->toString();
+    $this->assertEquals($link_url, 'https://example.net/foo');
+
+    $contact_url = $this->substitutionPlugin->getUrl($page_components['localgov_contact'])->toString();
+    $this->assertEquals($contact_url, 'https://example.net/bar');
+
+    $img_url = $this->substitutionPlugin->getUrl($page_components['localgov_image'])->toString();
+    $img_page_component_url = $page_components['localgov_image']->toUrl('canonical')->toString();
+    $this->assertEquals($img_url, $img_page_component_url);
+  }
+
+  /**
+   * Creates necessary test data for search and replacement.
+   *
+   * Creates three page components:
+   * - localgov_link
+   * - localgov_contact
+   * - localgov_image.
+   */
+  protected function addLinkAndContactPageComponents(): array {
 
     $link_para = Paragraph::create([
-      'title' => 'Test Paragraph Foo bar',
-      'type'  => 'localgov_link',
+      'title'        => 'Test Paragraph Foo bar',
+      'type'         => 'localgov_link',
+      'localgov_url' => 'https://example.net/foo',
     ]);
     $link_para->save();
     $link_page_component = LibraryItem::create([
@@ -105,8 +142,9 @@ class LinkItIntegrationTest extends KernelTestBase {
     $link_page_component->save();
 
     $contact_para = Paragraph::create([
-      'title' => 'Test Paragraph Baz qux',
-      'type'  => 'localgov_contact',
+      'title'                => 'Test Paragraph Baz qux',
+      'type'                 => 'localgov_contact',
+      'localgov_contact_url' => 'https://example.net/bar',
     ]);
     $contact_para->save();
     $contact_page_component = LibraryItem::create([
@@ -114,6 +152,23 @@ class LinkItIntegrationTest extends KernelTestBase {
       'paragraphs' => $contact_para,
     ]);
     $contact_page_component->save();
+
+    $img_para = Paragraph::create([
+      'title' => 'Test Paragraph image',
+      'type'  => 'localgov_image',
+    ]);
+    $img_para->save();
+    $img_page_component = LibraryItem::create([
+      'label'      => 'Image: Test Paragraph image',
+      'paragraphs' => $img_para,
+    ]);
+    $img_page_component->save();
+
+    return [
+      'localgov_link'    => $link_page_component,
+      'localgov_contact' => $contact_page_component,
+      'localgov_image'   => $img_page_component,
+    ];
   }
 
 }


### PR DESCRIPTION
The LinkIt [substitution plugin from this module](https://github.com/localgovdrupal/localgov_page_components/blob/1.x/src/Plugin/Linkit/Substitution/ParagraphsLibraryItem.php) has become incompatible with the recently released LinkIt version 6.1.1.  This is due to API changes.  Previously, [Drupal\linkit\SubstitutionInterface::getUrl()](https://git.drupalcode.org/project/linkit/-/blob/6.0.x/src/SubstitutionInterface.php?ref_type=heads#L23) was expected to return [Drupal\Core\GeneratedUrl](https://git.drupalcode.org/project/linkit/-/blob/6.1.0/src/SubstitutionInterface.php?ref_type=tags#L20).  Now it expects [Drupal\Core\Url](https://git.drupalcode.org/project/linkit/-/blob/6.1.1/src/SubstitutionInterface.php?ref_type=tags#L20).  Given this is a breaking change, the LinkIt project should have made a version 7.0.0 release instead of version 6.1.1.

Also added a test to cover the substitution plugin where this happened.

I had to drop Drupal 9 compatibility from this module as [LinkIt](https://www.drupal.org/project/linkit) 6.1.1 is incompatible with Drupal versions prior to 10.1.  Does it mean we need to start a 3.x (or 2.x) branch for this module? @finnlewis 