### PR TITLE
fix: keep module naming consistent

### DIFF
--- a/localgov_page_components.info.yml
+++ b/localgov_page_components.info.yml
@@ -1,4 +1,4 @@
-name: 'Localgov Page Components'
+name: 'LocalGov Page Components'
 type: module
 description: 'Disguise "Paragraphs library" as "Page components" for better UX.'
 core_version_requirement: ^10


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Keep the module naming consistent