### PR TITLE
feat: drupal 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/entity_browser": "^2.5",
         "drupal/inline_entity_form": "^1.0-rc6 || ^3.0",
-        "drupal/linkit": "^7.0",
+        "drupal/linkit": "^6.1 || ^7.0",
         "drupal/paragraphs": "^1.11"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/entity_browser": "^2.5",
         "drupal/inline_entity_form": "^1.0-rc6 || ^3.0",
-        "drupal/linkit": "~6.0.2 || ^6.1.1",
+        "drupal/linkit": "^7.0",
         "drupal/paragraphs": "^1.11"
     },
     "extra": {

--- a/localgov_page_components.info.yml
+++ b/localgov_page_components.info.yml
@@ -1,11 +1,11 @@
 name: 'LocalGov Page Components'
 type: module
 description: 'Disguise "Paragraphs library" as "Page components" for better UX.'
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 package: 'LocalGov Drupal'
 dependencies:
   - entity_browser:entity_browser
   - entity_browser:entity_browser_entity_form
   - inline_entity_form:inline_entity_form
-  - linkit:linkit (>=6.0.2)
+  - linkit:linkit
   - paragraphs:paragraphs_library


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #59 

Currently fails because we require drupal/linkit ^7.0 (latest recommended version) but this also needs to be bumped in localgov_core at the same time